### PR TITLE
feat: optimized article pagination

### DIFF
--- a/board-service/article/src/main/kotlin/com/scalable/article/controller/ArticleController.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/controller/ArticleController.kt
@@ -2,6 +2,7 @@ package com.scalable.article.controller
 
 import com.scalable.article.dto.request.ArticleCreateRequest
 import com.scalable.article.dto.request.ArticleUpdateRequest
+import com.scalable.article.dto.response.ArticlePageResponse
 import com.scalable.article.dto.response.ArticleResponse
 import com.scalable.article.service.ArticleService
 import org.springframework.http.ResponseEntity
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
@@ -21,6 +23,20 @@ class ArticleController(
     @GetMapping("/v1/articles/{articleId}")
     fun read(@PathVariable articleId: Long): ResponseEntity<ArticleResponse> {
         val response = articleService.read(articleId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/v1/articles")
+    fun readAll(
+        @RequestParam("boardId") boardId: Long,
+        @RequestParam("pageSize") pageSize: Long,
+        @RequestParam("page") page: Long,
+    ): ResponseEntity<ArticlePageResponse> {
+        val response = articleService.readAll(
+            boardId = boardId,
+            pageSize = pageSize,
+            page = page,
+        )
         return ResponseEntity.ok(response)
     }
 

--- a/board-service/article/src/main/kotlin/com/scalable/article/dto/response/ArticleResponse.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/dto/response/ArticleResponse.kt
@@ -26,3 +26,20 @@ data class ArticleResponse(
         }
     }
 }
+
+data class ArticlePageResponse(
+    val articles: List<ArticleResponse>,
+    val articleCount: Long,
+) {
+    companion object {
+        fun of(
+            articles: List<Article>,
+            articleCount: Long,
+        ): ArticlePageResponse {
+            return ArticlePageResponse(
+                articles = articles.map { article -> ArticleResponse.from(article) },
+                articleCount = articleCount,
+            )
+        }
+    }
+}

--- a/board-service/article/src/main/kotlin/com/scalable/article/entity/Article.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/entity/Article.kt
@@ -5,6 +5,10 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import java.time.LocalDateTime
 
+/**
+ *  Index
+ *  - create index idx_board_id_article_id on article(board_id asc, article_id desc);
+ */
 @Entity(name = "article")
 class Article(
     @Id

--- a/board-service/article/src/main/kotlin/com/scalable/article/global/PageHelper.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/global/PageHelper.kt
@@ -1,0 +1,18 @@
+package com.scalable.article.global
+
+object PageHelper {
+    fun getSearchablePageCount(
+        page: Long,
+        pageSize: Long,
+        searchablePageCount: Long,
+    ): Long {
+        return (((page - 1) / searchablePageCount) + 1) * pageSize * searchablePageCount + 1;
+    }
+
+    fun getOffset(
+        page: Long,
+        pageSize: Long,
+    ): Long {
+        return (page - 1) * pageSize
+    }
+}

--- a/board-service/article/src/main/kotlin/com/scalable/article/repository/ArticleRepository.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/repository/ArticleRepository.kt
@@ -2,9 +2,43 @@ package com.scalable.article.repository
 
 import com.scalable.article.entity.Article
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.data.repository.query.Param
 
-interface ArticleRepository : JpaRepository<Article, Long>
+interface ArticleRepository : JpaRepository<Article, Long> {
+    @Query(
+        value = """
+            select article.article_id, article.title, article.content, article.board_id, article.writer_id, article.created_at, article.modified_at
+            from (
+                select article_id
+                from article
+                where board_id = :boardId
+                order by article_id desc
+                limit :limit offset :offset
+            ) t left join article on t.article_id = article.article_id;
+        """,
+        nativeQuery = true,
+    )
+    fun findAll(
+        @Param("boardId") boardId: Long,
+        @Param("offset") offset: Long,
+        @Param("limit") limit: Long,
+    ): List<Article>
+
+    @Query(
+        value = """
+            select count(*) from (
+                select article_id from article where board_id = :boardId limit :limit
+            ) t
+        """,
+        nativeQuery = true,
+    )
+    fun countAll(
+        @Param("boardId") boardId: Long,
+        @Param("limit") limit: Long,
+    ): Long
+}
 
 fun ArticleRepository.findByIdOrThrow(id: Long): Article {
     return findByIdOrNull(id)

--- a/board-service/article/src/main/kotlin/com/scalable/article/service/ArticleService.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/service/ArticleService.kt
@@ -3,8 +3,10 @@ package com.scalable.article.service
 import com.common.snowflake.Snowflake
 import com.scalable.article.dto.request.ArticleCreateRequest
 import com.scalable.article.dto.request.ArticleUpdateRequest
+import com.scalable.article.dto.response.ArticlePageResponse
 import com.scalable.article.dto.response.ArticleResponse
 import com.scalable.article.entity.Article
+import com.scalable.article.global.PageHelper
 import com.scalable.article.repository.ArticleRepository
 import com.scalable.article.repository.findByIdOrThrow
 import org.springframework.stereotype.Service
@@ -46,5 +48,32 @@ class ArticleService(
     @Transactional
     fun delete(articleId: Long) {
         articleRepository.deleteById(articleId)
+    }
+
+    fun readAll(
+        boardId: Long,
+        page: Long,
+        pageSize: Long,
+    ): ArticlePageResponse {
+
+        val articles = articleRepository.findAll(
+            boardId = boardId,
+            offset = PageHelper.getOffset(
+                page = page,
+                pageSize = pageSize,
+            ),
+            limit = pageSize,
+        )
+
+        val articleCount = PageHelper.getSearchablePageCount(
+            page = page,
+            pageSize = pageSize,
+            searchablePageCount = 10,
+        )
+
+        return ArticlePageResponse.of(
+            articles = articles,
+            articleCount = articleCount,
+        )
     }
 }

--- a/board-service/article/src/test/kotlin/api/ArticleApiSimpleTest.kt
+++ b/board-service/article/src/test/kotlin/api/ArticleApiSimpleTest.kt
@@ -3,6 +3,7 @@ package api
 import com.scalable.article.ArticleApplication
 import com.scalable.article.dto.request.ArticleCreateRequest
 import com.scalable.article.dto.request.ArticleUpdateRequest
+import com.scalable.article.dto.response.ArticlePageResponse
 import com.scalable.article.dto.response.ArticleResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -119,6 +120,22 @@ class ArticleApiSimpleTest {
         assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
     }
 
+    @Test
+    fun `should read all articles successfully`() {
+        // when
+        val response = readAll(
+            boardId = 1L,
+            page = 599999L,
+            pageSize = 30L
+        )
+
+        // then
+        for(article in response.articles) {
+            println("Article: $article")
+        }
+
+    }
+
     private fun create(request: ArticleCreateRequest): ArticleResponse =
         client.post()
             .uri("/v1/articles")
@@ -133,6 +150,18 @@ class ArticleApiSimpleTest {
             .retrieve()
             .body(ArticleResponse::class.java)
             ?: throw IllegalStateException("Failed to read article")
+
+    private fun readAll(
+        boardId: Long,
+        page: Long,
+        pageSize: Long,
+    ): ArticlePageResponse {
+        return client.get()
+            .uri("/v1/articles?boardId=$boardId&page=$page&pageSize=$pageSize")
+            .retrieve()
+            .body(ArticlePageResponse::class.java)
+            ?: throw IllegalStateException("Failed to read articles")
+    }
 
     private fun update(articleId: Long, request: ArticleUpdateRequest): ArticleResponse =
         client.put()

--- a/board-service/article/src/test/kotlin/repository/ArticleRepositoryTest.kt
+++ b/board-service/article/src/test/kotlin/repository/ArticleRepositoryTest.kt
@@ -1,0 +1,37 @@
+package repository
+
+import com.scalable.article.ArticleApplication
+import com.scalable.article.repository.ArticleRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(
+    classes = [ArticleApplication::class]
+)
+class ArticleRepositoryTest {
+    @Autowired
+    lateinit var articleRepository: ArticleRepository
+
+    @Test
+    fun findAll() {
+        val articles = articleRepository.findAll(
+            boardId = 1L,
+            offset = 1598899L,
+            limit = 30L
+        )
+        for (article in articles) {
+            println(article)
+        }
+    }
+
+    @Test
+    fun countAll() {
+        articleRepository.countAll(
+            boardId = 1L,
+            limit = 100000L
+        ).also {
+            println(it)
+        }
+    }
+}

--- a/board-service/article/src/test/kotlin/util/PageHelperTest.kt
+++ b/board-service/article/src/test/kotlin/util/PageHelperTest.kt
@@ -1,0 +1,35 @@
+package util
+
+import com.scalable.article.global.PageHelper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PageHelperTest {
+
+    /**
+     *  특정 페이지와 페이지 크기, 검색 가능한 최대 페이지 개수에 따라,
+     *  전체 검색 가능한 항목 수(전체 페이지 수 * 페이지 크기)가 올바르게 계산되는지 검증.
+     */
+    @Test
+    fun `should count correct number of pages considering searchable page limit policy`() {
+        listOf(
+            TestCase(page = 1L, pageSize = 30L, searchablePageCount = 10L, expected = 301L),
+            TestCase(page = 7L, pageSize = 30L, searchablePageCount = 10L, expected = 301L),
+            TestCase(page = 12L, pageSize = 30L, searchablePageCount = 10L, expected = 601L)
+        ).forEach { testCase ->
+            val actual = PageHelper.getSearchablePageCount(
+                page = testCase.page,
+                pageSize = testCase.pageSize,
+                searchablePageCount = testCase.searchablePageCount
+            )
+            assertThat(actual).isEqualTo(testCase.expected)
+        }
+    }
+
+    private data class TestCase(
+        val page: Long,
+        val pageSize: Long,
+        val searchablePageCount: Long,
+        val expected: Long
+    )
+}


### PR DESCRIPTION
### Summary

- Implement article pagination API

### Optimize

1. Optimized SQL query to first target article_id using the secondary index (`idx_board_id_article_id`), then fetch full data via the clustered index for better performance 
      - Compared to query without indexing, execution time improved by over 90% (from ~3s to under .2s)
           -   on a test dataset with 14,000,000 records. (same board_id)

```sql
create index idx_board_id_article_id on article (board_id asc, article_id desc);

```

2. Use `Snowflake ID` for sorting instead of `created_at`. 
     -  When handling heavy traffic, `created_at` can lead to many records sharing the same value.

### Query Plan

- pagination query
```sql
select article.article_id,
       article.title,
       article.content,
       article.board_id,
       article.writer_id,
       article.created_at,
       article.modified_at
from (select article_id
      from article
      where board_id = :boardId
      order by article_id desc
      limit :limit offset :offset
    ) t
    left join article on t.article_id = article.article_id;
```


| id | select_type |    table    | partitions |  type  |     possible_keys      |          key           | key_len |      ref       |   rows    | filtered |     Extra     |
|----|-------------|-------------|------------|--------|------------------------|------------------------|---------|----------------|-----------|----------|---------------|
|  1 | PRIMARY     | <derived2>  | null       | ALL    | null                   | null                   | null    | null           | 1029      | 100      | null          |
|  1 | PRIMARY     | article     | null       | eq_ref | PRIMARY                | PRIMARY                | 8       | t.article_id   | 1         | 100      | null          |
|  2 | DERIVED     | article     | null       | ref    | idx_board_id_article_id| idx_board_id_article_id| 8       | const          | 7,368,420 | 100      | Using index   |

First, the secondary index(`idx_board_id_article_id`) helps narrow down the rows.

Then, the PRIMARY key ensures quick lookups for complete data.