### PR TITLE
Feat: simple Comment Create/Delete API and test datainitalizer 

### DIFF
--- a/board-service/comment/build.gradle
+++ b/board-service/comment/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
-}

--- a/board-service/comment/build.gradle.kts
+++ b/board-service/comment/build.gradle.kts
@@ -1,0 +1,6 @@
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    implementation(project(":common-service:snowflake"))
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/config/SnowflakeConfig.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/config/SnowflakeConfig.kt
@@ -1,0 +1,13 @@
+package com.scalable.comment.config
+
+import com.common.snowflake.Snowflake
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SnowflakeConfig {
+    @Bean
+    fun snowflake(): Snowflake {
+        return Snowflake()
+    }
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/controller/CommentController.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/controller/CommentController.kt
@@ -1,0 +1,41 @@
+package com.scalable.comment.controller
+
+import com.scalable.comment.dto.request.CommentCreateRequest
+import com.scalable.comment.dto.response.CommentResponse
+import com.scalable.comment.service.CommentService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CommentController(
+    private val commentService: CommentService,
+) {
+    @GetMapping("/v1/comments/{commentId}")
+    fun read(
+        @PathVariable("commentId") commentId: Long,
+    ): ResponseEntity<CommentResponse> {
+        val response = commentService.read(commentId)
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/v1/comments")
+    fun create(
+        @RequestBody request: CommentCreateRequest,
+    ): ResponseEntity<CommentResponse> {
+        val response = commentService.create(request)
+        return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("/v1/comments/{commentId}")
+    fun delete(
+        @PathVariable("commentId") commentId: Long,
+    ): ResponseEntity<Unit> {
+        commentService.delete(commentId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/dto/request/CommentCreateRequest.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/dto/request/CommentCreateRequest.kt
@@ -1,0 +1,8 @@
+package com.scalable.comment.dto.request
+
+data class CommentCreateRequest(
+    val articleId: Long,
+    val content: String,
+    val parentCommentId: Long?,
+    val writerId: Long,
+)

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/dto/response/CommentResponse.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/dto/response/CommentResponse.kt
@@ -1,0 +1,28 @@
+package com.scalable.comment.dto.response
+
+import com.scalable.comment.entity.Comment
+import java.time.LocalDateTime
+
+data class CommentResponse(
+    val commentId: Long,
+    val content: String,
+    val parentCommentId: Long,
+    val articleId: Long,
+    val writerId: Long,
+    val deleted: Boolean,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(comment: Comment): CommentResponse {
+            return CommentResponse(
+                commentId = comment.commentId,
+                content = comment.content,
+                parentCommentId = comment.parentCommentId,
+                articleId = comment.articleId,
+                writerId = comment.writerId,
+                deleted = comment.isDeleted,
+                createdAt = comment.createdAt,
+            )
+        }
+    }
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/entity/Comment.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/entity/Comment.kt
@@ -1,0 +1,50 @@
+package com.scalable.comment.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "comment")
+class Comment(
+    @Id
+    @Column(name = "comment_id", nullable = false, updatable = false)
+    var commentId: Long,
+    var content: String,
+    var parentCommentId: Long,
+    var articleId: Long, // shard key
+    var writerId: Long,
+    var isDeleted: Boolean,
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+) {
+    companion object {
+        fun of(
+            commentId: Long,
+            content: String,
+            parentCommentId: Long?,
+            articleId: Long,
+            writerId: Long,
+        ): Comment {
+            return Comment(
+                commentId = commentId,
+                content = content,
+                parentCommentId = parentCommentId ?: commentId,
+                articleId = articleId,
+                writerId = writerId,
+                isDeleted = false,
+            )
+        }
+    }
+
+    fun isRoot(): Boolean {
+        return parentCommentId == commentId
+    }
+
+    fun softDeleted(): Comment {
+        return this.apply {
+            isDeleted = true
+        }
+    }
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
@@ -1,0 +1,39 @@
+package com.scalable.comment.repository
+
+import com.scalable.comment.entity.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.data.repository.query.Param
+
+interface CommentRepository : JpaRepository<Comment, Long> {
+    @Query(
+        value = """
+            select count(*)
+            from (
+                select comment_id
+                from comment
+                where article_id = :articleId and parent_comment_id = :parentCommentId
+                limit :limit
+            ) t
+        """,
+        nativeQuery = true
+    )
+    fun countByArticleIdAndParentCommentId(
+        @Param("articleId") articleId: Long,
+        @Param("parentCommentId") parentCommentId: Long,
+        @Param("limit") limit: Long,
+    ): Long
+}
+
+
+fun CommentRepository.findByIdOrThrow(id: Long): Comment {
+    return findByIdOrNull(id)
+        ?: throw IllegalArgumentException("Comment with id $id not found (even if soft-deleted)")
+}
+
+fun CommentRepository.findActivatedByIdOrThrow(id: Long): Comment {
+    return findByIdOrNull(id)
+        ?.takeIf { !it.isDeleted }
+        ?: throw IllegalArgumentException("Comment with id $id not found or is soft-deleted")
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/service/CommentService.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/service/CommentService.kt
@@ -1,0 +1,76 @@
+package com.scalable.comment.service
+
+import com.common.snowflake.Snowflake
+import com.scalable.comment.dto.request.CommentCreateRequest
+import com.scalable.comment.dto.response.CommentResponse
+import com.scalable.comment.entity.Comment
+import com.scalable.comment.repository.CommentRepository
+import com.scalable.comment.repository.findActivatedByIdOrThrow
+import com.scalable.comment.repository.findByIdOrThrow
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CommentService(
+    private val commentRepository: CommentRepository,
+    private val snowflake: Snowflake,
+) {
+
+    @Transactional
+    fun create(request: CommentCreateRequest): CommentResponse {
+        val parent = findParent(request)
+        val savedComment = commentRepository.save(
+            Comment.of(
+                commentId = snowflake.nextId(),
+                content = request.content,
+                parentCommentId = parent?.commentId,
+                articleId = request.articleId,
+                writerId = request.writerId,
+            )
+        )
+        return CommentResponse.from(savedComment)
+    }
+
+    fun read(commentId: Long): CommentResponse {
+        return CommentResponse.from(
+            comment = commentRepository.findActivatedByIdOrThrow(commentId)
+        )
+    }
+
+    @Transactional
+    fun delete(commentId: Long) {
+        val comment = commentRepository.findActivatedByIdOrThrow(commentId)
+        if (comment.hasChildren()) {
+            comment.softDeleted()
+        } else {
+            deleteCascade(comment)
+        }
+    }
+
+    private fun deleteCascade(comment: Comment) {
+        commentRepository.delete(comment)
+        if (!comment.isRoot()) {
+            val parent = commentRepository.findByIdOrThrow(comment.parentCommentId)
+            // 이미 softDelete 된 부모이고, 더 이상 자식이 없으면
+            if (parent.isDeleted && !parent.hasChildren()) {
+                // 부모도 재귀적으로 삭제
+                deleteCascade(parent)
+            }
+        }
+    }
+
+    private fun Comment.hasChildren(): Boolean {
+        return commentRepository.countByArticleIdAndParentCommentId(
+            articleId = articleId,
+            parentCommentId = commentId,
+            limit = 2L,
+        ) == 2L
+    }
+
+
+    private fun findParent(request: CommentCreateRequest): Comment? {
+        return request.parentCommentId?.let { commentId ->
+            commentRepository.findActivatedByIdOrThrow(commentId)
+        }
+    }
+}

--- a/board-service/comment/src/main/resources/application.yml
+++ b/board-service/comment/src/main/resources/application.yml
@@ -1,2 +1,16 @@
 server:
   port: 8082
+spring:
+  application:
+    name: comment-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3307/comment
+    username: root
+    password: root
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: none

--- a/board-service/comment/src/test/kotlin/datainit/DataInitializer.kt
+++ b/board-service/comment/src/test/kotlin/datainit/DataInitializer.kt
@@ -1,0 +1,75 @@
+package datainit
+
+import com.common.snowflake.Snowflake
+import com.scalable.comment.CommentApplication
+import com.scalable.comment.entity.Comment
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+@SpringBootTest(
+    classes = [CommentApplication::class],
+)
+class DataInitializer {
+    companion object {
+        // INSERT EXECUTE_COUNT * CHUNK_SIZE records
+        private const val EXECUTE_COUNT = 8000;
+        private const val CHUNK_SIZE = 1000;
+    }
+
+    @PersistenceContext
+    lateinit var entityManager: EntityManager
+
+    @Autowired
+    lateinit var transactionTemplate: TransactionTemplate
+
+    @Autowired
+    lateinit var snowflake: Snowflake
+
+    private val latch = CountDownLatch(EXECUTE_COUNT)
+
+    @Test
+    fun init() {
+        Executors.newFixedThreadPool(10).use { executor ->
+            repeat(EXECUTE_COUNT) { count ->
+                executor.submit {
+                    try {
+                        insert()
+                        latch.countDown()
+                        println("Latch count: ${latch.count}, Task $count completed")
+                    } catch (e: Exception) {
+                        println("Error in task $count: ${e.message}")
+                    }
+                }
+            }
+            latch.await()
+        }
+        println("All tasks completed.")
+    }
+
+    private fun insert() {
+        transactionTemplate.executeWithoutResult {
+            var prevCommentId: Long? = null
+            repeat(CHUNK_SIZE) { index ->
+                val comment = Comment.of(
+                    commentId = snowflake.nextId(),
+                    content = "content$index",
+                    parentCommentId = if (index % 2 == 0) {
+                        null
+                    } else {
+                        prevCommentId
+                    },
+                    articleId = 1L,
+                    writerId = 1L,
+                )
+                prevCommentId = comment.commentId
+                entityManager.persist(comment)
+            }
+        }
+    }
+}

--- a/board-service/comment/src/test/kotlin/service/CommentServiceTest.kt
+++ b/board-service/comment/src/test/kotlin/service/CommentServiceTest.kt
@@ -1,6 +1,5 @@
 package service
 
-import com.common.snowflake.Snowflake
 import com.scalable.comment.CommentApplication
 import com.scalable.comment.entity.Comment
 import com.scalable.comment.repository.CommentRepository
@@ -26,7 +25,6 @@ class CommentServiceIntegrationTest {
     @BeforeEach
     fun clear() {
         commentRepository.deleteAll()
-        // 필요 시 초기 데이터 넣기
     }
 
     @Test

--- a/board-service/comment/src/test/kotlin/service/CommentServiceTest.kt
+++ b/board-service/comment/src/test/kotlin/service/CommentServiceTest.kt
@@ -23,9 +23,6 @@ class CommentServiceIntegrationTest {
     @Autowired
     lateinit var commentRepository: CommentRepository
 
-    @Autowired
-    lateinit var snowflake: Snowflake
-
     @BeforeEach
     fun clear() {
         commentRepository.deleteAll()

--- a/board-service/comment/src/test/kotlin/service/CommentServiceTest.kt
+++ b/board-service/comment/src/test/kotlin/service/CommentServiceTest.kt
@@ -1,0 +1,149 @@
+package service
+
+import com.common.snowflake.Snowflake
+import com.scalable.comment.CommentApplication
+import com.scalable.comment.entity.Comment
+import com.scalable.comment.repository.CommentRepository
+import com.scalable.comment.service.CommentService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@SpringBootTest(
+    classes = [CommentApplication::class],
+)
+class CommentServiceIntegrationTest {
+
+    @Autowired
+    lateinit var commentService: CommentService
+
+    @Autowired
+    lateinit var commentRepository: CommentRepository
+
+    @Autowired
+    lateinit var snowflake: Snowflake
+
+    @BeforeEach
+    fun clear() {
+        commentRepository.deleteAll()
+        // 필요 시 초기 데이터 넣기
+    }
+
+    @Test
+    fun `삭제할 댓글이 자식이 있다면, soft delete 한다`() {
+        // given
+        val parentId = 100L
+
+        val parent = commentRepository.save(
+            createComment(
+                commentId = parentId,
+                parentId = parentId,
+                content = "부모댓글",
+                isDeleted = false,
+            )
+        )
+        val child = commentRepository.save(
+            createComment(
+                commentId = 101L,
+                parentId = parentId,
+                content = "자식댓글",
+                isDeleted = false,
+            )
+        )
+
+        // when
+        commentService.delete(parentId)
+
+        // then
+        val foundParent = commentRepository.findById(parent.commentId).get()
+        val foundChild = commentRepository.findById(child.commentId).get()
+
+        assertTrue(foundParent.isDeleted, "부모 댓글은 soft-delete 되어야 함")
+        assertFalse(foundChild.isDeleted, "자식 댓글은 그대로 존재해야 함")
+    }
+
+    @Test
+    fun `하위 댓글이 삭제되고, 삭제되지 않은 부모면 하위 댓글만 삭제한다`() {
+        // given
+        val parentId = 200L
+        val childId = 201L
+        val parent = commentRepository.save(
+            createComment(
+                commentId = parentId,
+                parentId = parentId,
+                content = "부모댓글",
+                isDeleted = false,
+            )
+        )
+        val child = commentRepository.save(
+            createComment(
+                commentId = childId,
+                parentId = parentId,
+                content = "자식댓글",
+                isDeleted = false,
+            )
+        )
+
+        // when
+        commentService.delete(childId)
+
+        // then
+        val deletedChild = commentRepository.findById(childId)
+        assertFalse(deletedChild.isPresent, "자식 댓글은 DB에서 완전히 삭제되어야 함")
+
+        val foundParent = commentRepository.findById(parentId).get()
+        assertFalse(foundParent.isDeleted, "부모 댓글은 여전히 deleted = false 이어야 함")
+    }
+
+    @Test
+    fun `하위 댓글이 삭제되고, 이미 soft delete된 부모면 재귀적으로 모두 삭제한다`() {
+        // given
+        val parentId = 300L
+        val childId = 301L
+        val parent = commentRepository.save(
+            createComment(
+                commentId = parentId,
+                parentId = parentId,
+                content = "부모댓글(softDeleted)",
+                isDeleted = true,
+            )
+        )
+        commentRepository.save(
+            createComment(
+                commentId = childId,
+                parentId = parentId,
+                content = "자식댓글",
+                isDeleted = false,
+            )
+        )
+
+        // when
+        commentService.delete(childId)
+
+        // then
+        val deletedChild = commentRepository.findById(childId)
+        assertFalse(deletedChild.isPresent, "자식 댓글은 물리적으로 삭제되어야 함")
+
+        val deletedParent = commentRepository.findById(parentId)
+        assertFalse(deletedParent.isPresent, "부모 댓글도 재귀적으로 물리삭제되어야 함")
+    }
+
+    private fun createComment(
+        commentId: Long,
+        parentId: Long?,
+        content: String,
+        isDeleted: Boolean,
+    ): Comment {
+        return Comment(
+            commentId = commentId,
+            content = content,
+            parentCommentId = parentId ?: commentId,
+            articleId = 999L,
+            writerId = 11L,
+            isDeleted = isDeleted,
+        )
+    }
+}

--- a/board-service/comment/src/test/resources/application.yml
+++ b/board-service/comment/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8082
+spring:
+  application:
+    name: comment-service
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:comment;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ allprojects {
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+        testImplementation("com.h2database:h2")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
 


### PR DESCRIPTION
### Summary

- Creatae a simple APIs for Comment Create/Delete
    - Added CommentServiceIntegrateTest ( use h2 db )
- Added a  Comment data initalizer to construct a test dataset (8,000,000 or more)