### PR TITLE
feat/comment-read

### DIFF
--- a/board-service/article/src/main/kotlin/com/scalable/article/repository/ArticleRepository.kt
+++ b/board-service/article/src/main/kotlin/com/scalable/article/repository/ArticleRepository.kt
@@ -10,13 +10,10 @@ interface ArticleRepository : JpaRepository<Article, Long> {
     @Query(
         value = """
             select article.article_id, article.title, article.content, article.board_id, article.writer_id, article.created_at, article.modified_at
-            from (
-                select article_id
-                from article
-                where board_id = :boardId
-                order by article_id desc
-                limit :limit offset :offset
-            ) t left join article on t.article_id = article.article_id;
+            from article
+            where board_id = :boardId
+            order by article_id desc 
+            limit :limit offset :offset;
         """,
         nativeQuery = true,
     )

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/controller/CommentController.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/controller/CommentController.kt
@@ -1,6 +1,7 @@
 package com.scalable.comment.controller
 
 import com.scalable.comment.dto.request.CommentCreateRequest
+import com.scalable.comment.dto.response.CommentPageResponse
 import com.scalable.comment.dto.response.CommentResponse
 import com.scalable.comment.service.CommentService
 import org.springframework.http.ResponseEntity
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -20,6 +22,36 @@ class CommentController(
         @PathVariable("commentId") commentId: Long,
     ): ResponseEntity<CommentResponse> {
         val response = commentService.read(commentId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/v1/comments")
+    fun readAll(
+        @RequestParam("articleId") articleId: Long,
+        @RequestParam("pageSize") pageSize: Long,
+        @RequestParam("page") page: Long,
+    ): ResponseEntity<CommentPageResponse> {
+        val response = commentService.readAll(
+            articleId = articleId,
+            page = page,
+            pageSize = pageSize,
+        )
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/v1/comments/cursor")
+    fun readAll(
+        @RequestParam("articleId") articleId: Long,
+        @RequestParam(value = "lastParentCommentId", required = false) lastParentCommentId: Long?,
+        @RequestParam(value = "lastCommentId", required = false) lastCommentId: Long?,
+        @RequestParam("limit") limit: Long,
+    ): ResponseEntity<CommentPageResponse> {
+        val response = commentService.readAll(
+            articleId = articleId,
+            lastCommentId = lastCommentId,
+            lastParentCommentId = lastParentCommentId,
+            limit = limit,
+        )
         return ResponseEntity.ok(response)
     }
 

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/dto/response/CommentResponse.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/dto/response/CommentResponse.kt
@@ -26,3 +26,29 @@ data class CommentResponse(
         }
     }
 }
+
+data class CommentPageResponse(
+    val comments: List<CommentResponse>,
+    val commentCount: Long,
+) {
+    companion object {
+        fun of(
+            comments: List<Comment>,
+            commentCount: Long,
+        ): CommentPageResponse {
+            return CommentPageResponse(
+                comments = comments.map { comment -> CommentResponse.from(comment) },
+                commentCount = commentCount,
+            )
+        }
+
+        fun from(
+            comments: List<Comment>,
+        ): CommentPageResponse {
+            return CommentPageResponse(
+                comments = comments.map { comment -> CommentResponse.from(comment) },
+                commentCount = comments.size.toLong(),
+            )
+        }
+    }
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/global/PageHelper.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/global/PageHelper.kt
@@ -1,0 +1,18 @@
+package com.scalable.comment.global
+
+object PageHelper {
+    fun getSearchablePageCount(
+        page: Long,
+        pageSize: Long,
+        searchablePageCount: Long,
+    ): Long {
+        return (((page - 1) / searchablePageCount) + 1) * pageSize * searchablePageCount + 1;
+    }
+
+    fun getOffset(
+        page: Long,
+        pageSize: Long,
+    ): Long {
+        return (page - 1) * pageSize
+    }
+}

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
@@ -29,13 +29,10 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         value = """
             select comment.comment_id, comment.parent_comment_id, comment.article_id, comment.writer_id,
                    comment.content, comment.is_deleted,  comment.created_at
-            from (
-                select comment_id
-                from comment 
-                where article_id = :articleId
-                order by parent_comment_id, comment_id
-                limit :limit offset :offset
-            ) t left join comment on t.comment_id = comment.comment_id
+            from comment
+            where article_id = :articleId
+            order by parent_comment_id, comment_id 
+            limit :limit offset :offset
         """,
         nativeQuery = true
     )

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
@@ -24,6 +24,64 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         @Param("parentCommentId") parentCommentId: Long,
         @Param("limit") limit: Long,
     ): Long
+
+    @Query(
+        value = """
+            select comment.comment_id, comment.parent_comment_id, comment.article_id, comment.writer_id,
+                   comment.content, comment.is_deleted,  comment.created_at
+            from (
+                select comment_id
+                from comment 
+                where article_id = :articleId
+                order by parent_comment_id, comment_id
+                limit :limit offset :offset
+            ) t left join comment on t.comment_id = comment.comment_id
+        """,
+        nativeQuery = true
+    )
+    fun findAllByArticleId(
+        @Param("articleId") articleId: Long,
+        @Param("offset") offset: Long,
+        @Param("limit") limit: Long,
+    ): List<Comment>
+
+    @Query(
+        value = """
+            select count(*)
+            from (
+                select comment_id
+                from comment
+                where article_id = :articleId
+                limit :limit
+            ) t
+        """,
+        nativeQuery = true
+    )
+    fun countAll(
+        @Param("articleId") articleId: Long,
+        @Param("limit") limit: Long,
+    ): Long
+
+    @Query(
+        value = """
+            select comment.comment_id, comment.parent_comment_id, comment.article_id, comment.writer_id,
+                   comment.content, comment.is_deleted,  comment.created_at
+            from (
+                select comment_id
+                from comment 
+                where article_id = :articleId and (comment_id, parent_comment_id) > (:lastCommentId, :lastParentCommentId)
+                order by parent_comment_id, comment_id
+                limit :limit
+            ) t left join comment on t.comment_id = comment.comment_id
+        """,
+        nativeQuery = true
+    )
+    fun findAllByArticeIdAndLastCommentIdAndLastParentCommentId(
+        @Param("articleId") articleId: Long,
+        @Param("lastCommentId") lastCommentId: Long,
+        @Param("lastParentCommentId") lastParentCommentId: Long,
+        @Param("limit") limit: Long,
+    ): List<Comment>
 }
 
 

--- a/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
+++ b/board-service/comment/src/main/kotlin/com/scalable/comment/repository/CommentRepository.kt
@@ -66,13 +66,12 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         value = """
             select comment.comment_id, comment.parent_comment_id, comment.article_id, comment.writer_id,
                    comment.content, comment.is_deleted,  comment.created_at
-            from (
-                select comment_id
-                from comment 
-                where article_id = :articleId and (comment_id, parent_comment_id) > (:lastCommentId, :lastParentCommentId)
-                order by parent_comment_id, comment_id
-                limit :limit
-            ) t left join comment on t.comment_id = comment.comment_id
+            from comment
+            where article_id = :articleId and (
+                comment_id > :lastCommentId or 
+                (comment_id = :lastCommentId and parent_comment_id > :lastParentCommentId) 
+            )
+            order by parent_comment_id, comment_id limit :limit
         """,
         nativeQuery = true
     )


### PR DESCRIPTION
### Summary

- Implement a simple Read API for comments (only 2 depth is considered)

### Index

```sql
create index idx_article_id_parent_comment_id_comment_id on comment (article_id asc, parent_comment_id asc, comment_id asc);
```

### Query Plan

```sql
explain analyze select comment.comment_id, comment.parent_comment_id, comment.article_id, comment.writer_id,
                       comment.content, comment.is_deleted,  comment.created_at
                from comment
                where article_id = 1
                order by parent_comment_id, comment_id
                limit 30 offset 10000;
```
- Result
  ```sql
    -> Limit/Offset: 30/10000 row(s)  (cost=538943 rows=30) (actual time=22.9..23 rows=30 loops=1)
    -> Index lookup on comment using idx_article_id_parent_comment_id_comment_id (article_id=1)  (cost=538943 rows=4.01e+6) (actual time=0.264..22.5 rows=10030 loops=1)
    
   ```
  
```sql
explain analyze
select comment.comment_id,
       comment.parent_comment_id,
       comment.content,
       comment.article_id,
       comment.writer_id,
       comment.content,
       comment.is_deleted,
       comment.created_at
from comment
where article_id = 1
  and (
    parent_comment_id > 142539921307124354
        or
    (parent_comment_id = 142539921307124354 and comment_id > 142539921307124350)
    )
order by parent_comment_id, comment_id
limit 30;
```
- Result
    ```sql
  -> Limit: 30 row(s)  (cost=406 rows=30) (actual time=1.23..4.57 rows=30 loops=1)
    -> Index range scan on comment using idx_article_id_parent_comment_id_comment_id over (article_id = 1 AND parent_comment_id = 142539921307124354 AND 142539921307124350 < comment_id) OR (article_id = 1 AND 142539921307124354 < parent_comment_id), with index condition: ((`comment`.article_id = 1) and ((`comment`.parent_comment_id > 142539921307124354) or ((`comment`.parent_comment_id = 142539921307124354) and (`comment`.comment_id > 142539921307124350))))  (cost=406 rows=358) (actual time=1.2..4.54 rows=30 loops=1)
    ```
